### PR TITLE
Add status code to thrown ApiError exceptions

### DIFF
--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -74,7 +74,7 @@ class QPApi(object):
             body = response.text
 
         if response.status_code >= 400:
-            raise exceptions.ApiError(body)
+            raise exceptions.ApiError(body, response.status_code)
 
         if raw:
             return [response.status_code, response.text, response.headers]

--- a/quickpay_api_client/exceptions.py
+++ b/quickpay_api_client/exceptions.py
@@ -1,6 +1,7 @@
 class ApiError(Exception):
-    def __init__(self, api_error):
+    def __init__(self, api_error, status_code):
         self.body = api_error
+        self.status_code = status_code
         if isinstance(api_error, dict):
             self.message = "Error from Quickpay API. Details:\n Message: {0}".format(
                 api_error["message"])


### PR DESCRIPTION
It seems like it is an oversight that you are not able to get the actual underlying status code for errors.

For something like: /subscriptions/{id}/recurring i would like to know which of the errors it is:
400 | Invalid parameters
403 | Not authorized
404 | Not found

And that is not possible with the current implementation