### PR TITLE
Replacing httppretty with responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests

--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -10,14 +10,12 @@ from requests.packages.urllib3.poolmanager import PoolManager
 from quickpay_api_client import exceptions
 import quickpay_api_client
 
-
 class QPAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
                                        block=block,
                                        ssl_version=ssl.PROTOCOL_TLSv1)
-
 
 class QPApi(object):
     api_version = '10'

--- a/quickpay_api_client/tests/api_tests.py
+++ b/quickpay_api_client/tests/api_tests.py
@@ -3,46 +3,48 @@ from nose.tools import assert_equal, assert_raises
 import requests
 from quickpay_api_client.api import QPApi
 from quickpay_api_client.exceptions import ApiError
-import httpretty
-
+import responses
 
 class TestApi(object):
     def setup(self):
-        httpretty.enable()
         self.api = QPApi(secret="foo:bar")
         self.url = "{0}{1}".format(self.api.base_url, '/test')
 
     def setup_request(self):
-        httpretty.register_uri(httpretty.GET, self.url,
-                               body=json.dumps({'id': 123}),
-                               content_type='application/json')
+        responses.add(responses.GET, self.url,
+                    json={'id': 123},
+                    headers={"x-quickpay-server" : "QP-TEST"})
 
+    @responses.activate
     def test_perform_success(self):
         self.setup_request()
         res = self.api.perform('get', "/test")
         assert_equal(res['id'], 123)
 
+    @responses.activate
     def test_perform_failure(self):
-        httpretty.register_uri(httpretty.GET, self.url,
+        responses.add(responses.GET, self.url,
                                status=500,
-                               body=json.dumps({'message': 'dummy'}))
+                               json={'message': 'dummy'})
 
         assert_raises(ApiError, self.api.perform, 'get', '/test')
 
+    @responses.activate
     def test_headers(self):
         self.setup_request()
         res = self.api.perform('get', '/test')
 
-        req_headers = httpretty.last_request().headers
+        req_headers = responses.calls[0].request.headers
         assert_equal(req_headers['Authorization'], 'Basic Zm9vOmJhcg==')
         assert_equal(req_headers['Accept-Version'], 'v10')
         assert req_headers['User-Agent']
 
+    @responses.activate
     def test_perform_when_raw(self):
         self.setup_request()
         res = self.api.perform('get', '/test', raw=True)
 
         assert_equal(res[0], 200)
         assert_equal(res[1], '{"id": 123}')
-        assert_equal(res[2]['server'], 'Python/HTTPretty')
+        assert_equal(res[2]['x-quickpay-server'], 'QP-TEST')
         assert_equal(res[2]['content-type'], 'application/json')

--- a/quickpay_api_client/tests/client_tests.py
+++ b/quickpay_api_client/tests/client_tests.py
@@ -3,7 +3,6 @@ from quickpay_api_client.api import QPApi
 from quickpay_api_client import QPClient
 from mock import MagicMock
 
-
 class TestQPClient(object):
     def setup(self):
         self.client = QPClient('foobar')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.5
 nose===1.3.6
-httpretty===0.8.8
+responses===0.8.1
 mock===1.0.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys, re
 
 reqs = ['requests>=2.5']
 
-tests_requires = ['nose', 'httpretty', 'mock']
+tests_requires = ['nose', 'responses', 'mock']
 
 version = ''
 with open('quickpay_api_client/__init__.py', 'r') as fd:


### PR DESCRIPTION
This PR adds following -

- Fixes the failing tests
- Replaces httppretty with [responses](https://github.com/getsentry/responses) library for better mocking http requests.
- Drops support for Python 2.6/3.2 which doesn't get security updates and used rarely
- Adds support for Python 3.4, 3.5

closes #6 