### PR TITLE
Support Callback Url in API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [UNRELEASED] - 0000-00-00
+### Added
+- Support callback_url in API requests (#10)

--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -50,6 +50,10 @@ class QPApi(object):
             "User-Agent": "quickpay-python-client, v%s" % quickpay_api_client.__version__
         }
 
+        callback_url = kwargs.pop("callback_url", None)
+        if callback_url:
+            headers["Quickpay-Callback-Url"] = callback_url
+
         if self.secret:
             headers["Authorization"
                     ] = "Basic {0}".format(_base64_encode(self.secret))

--- a/quickpay_api_client/tests/api_tests.py
+++ b/quickpay_api_client/tests/api_tests.py
@@ -44,6 +44,15 @@ class TestApi(object):
         assert req_headers['User-Agent']
 
     @responses.activate
+    def test_callback_url_headers(self):
+        self.setup_request()
+        callback_url = "https://foo.bar"
+        res = self.api.perform("get", "/test", callback_url=callback_url)
+
+        req_headers = responses.calls[0].request.headers
+        assert_equal(req_headers['Quickpay-Callback-Url'], callback_url)
+
+    @responses.activate
     def test_perform_when_raw(self):
         self.setup_request()
         res = self.api.perform('get', '/test', raw=True)


### PR DESCRIPTION
Adds support for specifying callback URL into headers. 

closes #10 