### PR TITLE
deprecating TLS 1.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 # command to install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED] - 0000-00-00
 ### Added
 - Support callback_url in API requests (#10)
+- Upgrade to TLS1_1 (#11)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or install via [pip](https://github.com/pypa/pip):
 
     $ pip install quickpay-api-client
 
-It is currently tested with Python >= 2.5 and Python 3.
+It is currently tested with Python >= `2.7.9` and Python >= `3.4`.
 
 Usage
 =====

--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -15,7 +15,7 @@ class QPAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
                                        block=block,
-                                       ssl_version=ssl.PROTOCOL_TLSv1)
+                                       ssl_version=ssl.PROTOCOL_TLSv1_1)
 
 class QPApi(object):
     api_version = '10'


### PR DESCRIPTION
closes #11 

Deprecats TLS 1.0 as part of our PCI compliance.