### PR TITLE
Make Quickpay-Callback-Url header explicit

### DIFF
--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -10,6 +10,11 @@ from requests.packages.urllib3.poolmanager import PoolManager
 from quickpay_api_client import exceptions
 import quickpay_api_client
 
+def merge_dicts(x, y):
+    z = x.copy()
+    z.update(y)
+    return z
+
 class QPAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(num_pools=connections,
@@ -45,14 +50,11 @@ class QPApi(object):
         raw = kwargs.pop('raw', False)
         url = "{0}{1}".format(self.base_url, path)
 
-        headers = {
+        default_headers = {
             "Accept-Version": 'v%s' % self.api_version,
             "User-Agent": "quickpay-python-client, v%s" % quickpay_api_client.__version__
         }
-
-        callback_url = kwargs.pop("callback_url", None)
-        if callback_url:
-            headers["QuickPay-Callback-Url"] = callback_url
+        headers = merge_dicts(default_headers, kwargs.pop('headers', {}))
 
         if self.secret:
             headers["Authorization"

--- a/quickpay_api_client/tests/api_tests.py
+++ b/quickpay_api_client/tests/api_tests.py
@@ -47,7 +47,7 @@ class TestApi(object):
     def test_callback_url_headers(self):
         self.setup_request()
         callback_url = "https://foo.bar"
-        res = self.api.perform("get", "/test", callback_url=callback_url)
+        res = self.api.perform("get", "/test", headers={'QuickPay-Callback-Url': callback_url})
 
         req_headers = responses.calls[0].request.headers
         assert_equal(req_headers['QuickPay-Callback-Url'], callback_url)


### PR DESCRIPTION
An alternative fix for #16. This way `Quickpay-Callback-Url` header has to be set explicit and no magic happens behind the scenes