### PR TITLE
API: supporting body, headers, query as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+
+### Breaking
+- [Sending request with body, headers, and query](https://github.com/QuickPay/quickpay-python-client/issues/16#issuecomment-474115554)
+
 ### Fixed
 - [Callback header typo fix](https://github.com/QuickPay/quickpay-python-client/issues/16)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ else:
     print "Error", body
 ```
 
+Beyond the endpoint, the client accepts the following options (default values shown):
+
+* `body: ""` ( valid for POST, PATCH and PUT)
+* `headers: {}`
+* `query: {}`
+* `raw: false`
+
+```python
+response = client.post("/payments/1/capture",
+  body={ 'amount': 100 },
+  query={ "synchronized" : "" },
+  raw=False
+)
+```
+
 Handling API exceptions
 ----------------------
 

--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -45,6 +45,7 @@ class QPApi(object):
 
     def perform(self, method, path, **kwargs):
         raw = kwargs.pop('raw', False)
+        ssl_verify = kwargs.pop("verify", True)
         url = "{0}{1}".format(self.base_url, path)
 
         headers = {
@@ -73,12 +74,14 @@ class QPApi(object):
                                     data=body,
                                     params=query,
                                     headers=headers,
-                                    timeout=self.timeout)
+                                    timeout=self.timeout,
+                                    verify=ssl_verify)
         else:
             response = self.fulfill(method, url,
                                     params=query,
                                     headers=headers,
-                                    timeout=self.timeout)
+                                    timeout=self.timeout,
+                                    verify=ssl_verify)
 
         if response.headers.get('content-type') == 'application/json':
             body = response.json()


### PR DESCRIPTION
The positional arguments passed in curd actions were magically intercepted which might be problematic in some use cases for example [comment](https://github.com/QuickPay/quickpay-python-client/issues/16#issuecomment-473876330).

This adds support for better positional arguments for customizing curd operations with -
 
* `body: ""` ( valid for POST, PATCH and PUT)
* `headers: {}`
* `query: {}`
* `raw: False`

closes #16 

PS: it's a breaking change for we should release a major version.