### PR TITLE
deprecate TLS 1.1

### DIFF
--- a/quickpay_api_client/api.py
+++ b/quickpay_api_client/api.py
@@ -16,7 +16,7 @@ class QPAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
                                        block=block,
-                                       ssl_version=ssl.PROTOCOL_TLSv1_1)
+                                       ssl_version=ssl.PROTOCOL_TLSv1_2)
 
 
 class QPApi(object):


### PR DESCRIPTION
TLS 1.1 is due to be deprecated in [march this year](https://webkit.org/blog/8462/deprecation-of-legacy-tls-1-0-and-1-1-versions/).
Since TLS 1.3 support is not yet in the ssl module, this will have to make due for now.